### PR TITLE
SSEMR-614 Transfer Out & Died clients should not appear in Missed Apointment,IIT,cIIT, VL Due, and HVL linelists.

### DIFF
--- a/omod/src/main/java/org/openmrs/module/ssemrws/constants/SharedConstants.java
+++ b/omod/src/main/java/org/openmrs/module/ssemrws/constants/SharedConstants.java
@@ -1010,4 +1010,59 @@ public class SharedConstants {
 		
 		return (hasCollected && !hasReceived) ? "Yes" : "No";
 	}
+	
+	/**
+	 * Calculates the age of a patient based on their birthdate.
+	 */
+	public static Period calculatePatientAge(Patient patient) {
+		LocalDate birthDate = patient.getBirthdate().toInstant().atZone(java.time.ZoneId.systemDefault()).toLocalDate();
+		return Period.between(birthDate, LocalDate.now());
+	}
+	
+	/**
+	 * Formats the patient's age into a human-readable string.
+	 */
+	public static String formatAge(Period age) {
+		int years = age.getYears();
+		int months = age.getMonths();
+		
+		if (years >= 1) {
+			return years + " year" + (years > 1 ? "s" : "");
+		}
+		if (months >= 1) {
+			return months + " month" + (months > 1 ? "s" : "");
+		}
+		
+		long weeks = age.getDays() / 7;
+		return weeks + " week" + (weeks > 1 ? "s" : "");
+	}
+	
+	/**
+	 * Fetches the last encounter for a given patient and encounter type.
+	 * 
+	 * @param patient The patient
+	 * @param encounterType The encounter type
+	 * @return The most recent encounter of the given type for the patient, or null if none exist
+	 */
+	public static Encounter getLastEncounterForType(Patient patient, EncounterType encounterType) {
+		List<Encounter> encounters = Context.getEncounterService().getEncounters(patient, null, null, null, null,
+		    Collections.singletonList(encounterType), null, null, null, false);
+		if (!encounters.isEmpty()) {
+			encounters.sort((e1, e2) -> e2.getEncounterDatetime().compareTo(e1.getEncounterDatetime()));
+			return encounters.get(0);
+		}
+		return null;
+	}
+	
+	/**
+	 * Fetches the most recent active visit for a given patient.
+	 */
+	public static Visit getLatestActiveVisit(Patient patient) {
+		List<Visit> activeVisits = Context.getVisitService().getActiveVisitsByPatient(patient);
+		if (activeVisits.isEmpty()) {
+			return null;
+		}
+		activeVisits.sort(Comparator.comparing(Visit::getStartDatetime).reversed());
+		return activeVisits.get(0);
+	}
 }

--- a/omod/src/main/java/org/openmrs/module/ssemrws/queries/GetDueForVL.java
+++ b/omod/src/main/java/org/openmrs/module/ssemrws/queries/GetDueForVL.java
@@ -94,8 +94,8 @@ public class GetDueForVL {
 				// are still Unsuppressed. Eligible after Third EAC Date
 		        + "or (hvl.third_eac_session_date is not null "
 		        + " AND TIMESTAMPDIFF(MONTH, hvl.third_eac_session_date, :endDate) >= 1) " + ") "
-		        + "and fp.encounter_datetime <= :endDate " + "and (fup.death IS NULL OR fup.death != 'Yes') "
-		        + "and (fup.transfer_out IS NULL OR fup.transfer_out != 'Yes') "
+		        + "and fp.encounter_datetime <= :endDate "
+		        + "AND NOT ((fup.death = 'Yes' AND fup.date_of_death IS NOT NULL) OR (fup.transfer_out = 'Yes' AND fup.transfer_out_date IS NOT NULL)) "
 		        + "and (fup.client_refused_treatment IS NULL OR fup.client_refused_treatment != 'Yes')"
 		        + "and (appt.status IS NULL OR appt.status != 'Missed' OR DATEDIFF(:endDate, appt.start_date_time) <= 28)";
 		try {

--- a/omod/src/main/java/org/openmrs/module/ssemrws/queries/GetInterruptedInTreatment.java
+++ b/omod/src/main/java/org/openmrs/module/ssemrws/queries/GetInterruptedInTreatment.java
@@ -34,9 +34,9 @@ public class GetInterruptedInTreatment {
 		        + "LEFT JOIN ssemr_etl.ssemr_flat_encounter_hiv_care_follow_up e ON e.client_id = p.patient_id "
 		        + "LEFT JOIN ssemr_etl.ssemr_flat_encounter_end_of_follow_up f ON f.client_id = p.patient_id "
 		        + "WHERE p.status = 'Missed' " + "AND DATE(e.encounter_datetime) <= DATE(:endDate) "
-		        + "AND DATEDIFF(CURDATE(), p.start_date_time) > 28 " + "AND (f.death IS NULL OR f.death != 'Yes') "
-		        + "AND (f.transfer_out IS NULL OR f.transfer_out != 'Yes') "
+		        + "AND DATEDIFF(CURDATE(), p.start_date_time) > 28 "
 		        + "AND (f.client_refused_treatment IS NULL OR f.client_refused_treatment != 'Yes') "
+		        + "AND NOT ((f.death = 'Yes' AND f.date_of_death IS NOT NULL) OR (f.transfer_out = 'Yes' AND f.transfer_out_date IS NOT NULL)) "
 		        + "ORDER BY p.patient_id ASC " + ") AS t;";
 		
 		// Execute the query

--- a/omod/src/main/java/org/openmrs/module/ssemrws/queries/GetInterruptedInTreatmentWithinRange.java
+++ b/omod/src/main/java/org/openmrs/module/ssemrws/queries/GetInterruptedInTreatmentWithinRange.java
@@ -35,7 +35,7 @@ public class GetInterruptedInTreatmentWithinRange {
 		        + "WHERE p.status = 'Missed' "
 		        + "AND DATE_ADD(p.start_date_time, INTERVAL 28 DAY) BETWEEN :startDate AND :endDate "
 		        + "AND DATE(e.encounter_datetime) <= DATE(:endDate) " + "AND DATEDIFF(CURDATE(), p.start_date_time) > 28 "
-		        + "AND (f.death IS NULL OR f.death != 'Yes') " + "AND (f.transfer_out IS NULL OR f.transfer_out != 'Yes') "
+		        + "AND NOT ((f.death = 'Yes' AND f.date_of_death IS NOT NULL) OR (f.transfer_out = 'Yes' AND f.transfer_out_date IS NOT NULL)) "
 		        + "AND (f.client_refused_treatment IS NULL OR f.client_refused_treatment != 'Yes') "
 		        + "ORDER BY p.patient_id ASC " + ") AS t";
 		

--- a/omod/src/main/java/org/openmrs/module/ssemrws/queries/GetMissedAppointments.java
+++ b/omod/src/main/java/org/openmrs/module/ssemrws/queries/GetMissedAppointments.java
@@ -35,7 +35,10 @@ public class GetMissedAppointments {
 		String query = "select distinct fp.patient_id from openmrs.patient_appointment fp "
 		        + "join openmrs.person p on fp.patient_id = p.person_id " + "where p.uuid is not null "
 		        + "and fp.status = 'Missed' " + "and fp.start_date_time >= :cutoffDate "
-		        + "and fp.start_date_time between :startDate and :endDate";
+		        + "and fp.start_date_time between :startDate and :endDate "
+		        + "and fp.patient_id not in (select eofu.client_id from ssemr_etl.ssemr_flat_encounter_end_of_follow_up eofu "
+		        + "where (eofu.death = 'Yes' and eofu.date_of_death is not null) "
+		        + "or (eofu.transfer_out = 'Yes' and eofu.transfer_out_date is not null))";
 		
 		List<Integer> missedAppointmentIds = entityManager.createNativeQuery(query).setParameter("cutoffDate", cutoffDate)
 		        .setParameter("startDate", startDate).setParameter("endDate", endDate).getResultList();

--- a/omod/src/main/java/org/openmrs/module/ssemrws/web/constants/AllConcepts.java
+++ b/omod/src/main/java/org/openmrs/module/ssemrws/web/constants/AllConcepts.java
@@ -181,5 +181,11 @@ public class AllConcepts {
 	public static final String DIASTOLIC_BLOOD_PRESSURE = "5086AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 	
 	public static final String ON_TB = "58ab89cd-6674-480b-95a0-5b761b0275cb";
+
+	public static final String ADULT_AND_ADOLESCENT_INTAKE_FORM_ENCOUNTERTYPE_UUID = "b645dbdd-7d58-41d4-9b11-eeff023b8ee5";
+
+	public static final String PEDIATRIC_INTAKE_FORM_ENCOUNTERTYPE_UUID = "356def6a-fa66-4a78-97d5-b43154064875";
+
+	public static final String HIGH_VL_FORM_ENCOUNTERTYPE_UUID = "f7f1c854-69e5-11ee-8c99-0242ac120002";
 	
 }

--- a/omod/src/main/java/org/openmrs/module/ssemrws/web/controller/FormsController.java
+++ b/omod/src/main/java/org/openmrs/module/ssemrws/web/controller/FormsController.java
@@ -21,6 +21,7 @@ import java.time.Period;
 import java.util.List;
 
 import static org.openmrs.module.ssemrws.constants.SharedConstants.*;
+import static org.openmrs.module.ssemrws.web.constants.AllConcepts.*;
 
 /**
  * This class configured as controller using annotation and mapped with the URL of
@@ -29,12 +30,6 @@ import static org.openmrs.module.ssemrws.constants.SharedConstants.*;
 @Controller
 @RequestMapping(value = "/rest/" + RestConstants.VERSION_1 + "/ssemr")
 public class FormsController {
-	
-	public static final String ADULT_AND_ADOLESCENT_INTAKE_FORM_ENCOUNTERTYPE_UUID = "b645dbdd-7d58-41d4-9b11-eeff023b8ee5";
-	
-	public static final String PEDIATRIC_INTAKE_FORM_ENCOUNTERTYPE_UUID = "356def6a-fa66-4a78-97d5-b43154064875";
-	
-	public static final String HIGH_VL_FORM_ENCOUNTERTYPE_UUID = "f7f1c854-69e5-11ee-8c99-0242ac120002";
 	
 	/**
 	 * Gets a list of available/completed forms for a patient


### PR DESCRIPTION
…intment,IIT,cIIT, VL Due, and HVL linelists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved patient filtering in various reports to exclude only those confirmed deceased (with date of death) or transferred out (with transfer out date).
  - Missed appointments report now excludes patients no longer active due to death or transfer, ensuring more precise results.
- **New Features**
  - Added patient age calculation and formatting for clearer age representation.
  - Introduced retrieval of the latest encounters and active visits for patients.
  - Added new encounter type identifiers for adult/adolescent intake, pediatric intake, and high viral load forms.
- **Refactor**
  - Enhanced form retrieval process with modular helper methods for age, viral load status, and form filtering, improving readability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->